### PR TITLE
Sonar configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(sonar_driver_interfaces REQUIRED)
 
 # ezsocket
 add_library(ezsocket 
@@ -48,7 +49,8 @@ ament_target_dependencies(oculusDriver
   rclcpp
   std_msgs
   sensor_msgs
-  geometry_msgs)
+  geometry_msgs
+  sonar_driver_interfaces)
 
 target_include_directories(oculusDriver PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@ A ROS 2 sonar driver for Oculus imaging sonars.
 Currently only being developed for the blueprint subsea oculus M1200d dual-frequency multi-beam imaging sonar.
 
 Developed for ROS 2 foxy fitzroy
+
+## Dependencies
+- [ROS 2](https://docs.ros.org/en/foxy/index.html)
+- [Sonar Driver Interfaces](https://github.com/bastianschildknecht/sonar_driver_interfaces)

--- a/include/sonar_driver/oculusDriver/oculusDriverNode.hxx
+++ b/include/sonar_driver/oculusDriver/oculusDriverNode.hxx
@@ -9,6 +9,7 @@
 #include "sensor_msgs/msg/temperature.hpp"
 #include "geometry_msgs/msg/vector3_stamped.hpp"
 #include "sonar_driver_interfaces/msg/sonar_configuration.hpp"
+#include "sonar_driver_interfaces/msg/sonar_configuration_change.hpp"
 
 #ifndef OCULUSDRIVERNODE_HXX
 #define OCULUSDRIVERNODE_HXX
@@ -19,25 +20,26 @@ public:
     static OculusDriverNode *getInstace();
     OculusDriverNode(const char *nodeName);
     ~OculusDriverNode();
-    void addConfigurationListener(std::function<void(sonar_driver_interfaces::msg::SonarConfiguration::SharedPtr)> callback);
+    void addConfigurationListener(std::function<void(sonar_driver_interfaces::msg::SonarConfigurationChange::SharedPtr)> callback);
 
     std_msgs::msg::Header *commonHeader;
     sensor_msgs::msg::Image *sonarImage;
     sensor_msgs::msg::FluidPressure *sonarPressure;
     sensor_msgs::msg::Temperature *sonarTemperature;
+    sonar_driver_interfaces::msg::SonarConfiguration *sonarConfiguration;
     geometry_msgs::msg::Vector3Stamped *sonarOrientation;
     rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr imagePublisher;
     rclcpp::Publisher<sensor_msgs::msg::FluidPressure>::SharedPtr pressurePublisher;
     rclcpp::Publisher<sensor_msgs::msg::Temperature>::SharedPtr temperaturePublisher;
     rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr orientationPublisher;
     rclcpp::Publisher<sonar_driver_interfaces::msg::SonarConfiguration>::SharedPtr configurationPublisher;
-    rclcpp::Subscription<sonar_driver_interfaces::msg::SonarConfiguration>::SharedPtr configurationSubscriber;
+    rclcpp::Subscription<sonar_driver_interfaces::msg::SonarConfigurationChange>::SharedPtr configurationChangeSubscriber;
 
 protected:
     inline static OculusDriverNode *instance = nullptr;
 
-    std::vector<std::function<void(sonar_driver_interfaces::msg::SonarConfiguration::SharedPtr)>> *configurationListeners;
-    void configurationCallback(sonar_driver_interfaces::msg::SonarConfiguration::SharedPtr msg);
+    std::vector<std::function<void(sonar_driver_interfaces::msg::SonarConfigurationChange::SharedPtr)>> *configurationListeners;
+    void configurationCallback(sonar_driver_interfaces::msg::SonarConfigurationChange::SharedPtr msg);
 };
 
 #endif

--- a/include/sonar_driver/oculusDriver/oculusDriverNode.hxx
+++ b/include/sonar_driver/oculusDriver/oculusDriverNode.hxx
@@ -1,11 +1,14 @@
 // File: oculusDriverNode.hxx
 #include <stdint.h>
+#include <vector>
+#include <functional>
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/header.hpp"
 #include "sensor_msgs/msg/image.hpp"
 #include "sensor_msgs/msg/fluid_pressure.hpp"
 #include "sensor_msgs/msg/temperature.hpp"
 #include "geometry_msgs/msg/vector3_stamped.hpp"
+#include "sonar_driver_interfaces/msg/sonar_configuration.hpp"
 
 #ifndef OCULUSDRIVERNODE_HXX
 #define OCULUSDRIVERNODE_HXX
@@ -16,6 +19,8 @@ public:
     static OculusDriverNode *getInstace();
     OculusDriverNode(const char *nodeName);
     ~OculusDriverNode();
+    void addConfigurationListener(std::function<void(sonar_driver_interfaces::msg::SonarConfiguration::SharedPtr)> callback);
+
     std_msgs::msg::Header *commonHeader;
     sensor_msgs::msg::Image *sonarImage;
     sensor_msgs::msg::FluidPressure *sonarPressure;
@@ -25,9 +30,14 @@ public:
     rclcpp::Publisher<sensor_msgs::msg::FluidPressure>::SharedPtr pressurePublisher;
     rclcpp::Publisher<sensor_msgs::msg::Temperature>::SharedPtr temperaturePublisher;
     rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr orientationPublisher;
+    rclcpp::Publisher<sonar_driver_interfaces::msg::SonarConfiguration>::SharedPtr configurationPublisher;
+    rclcpp::Subscription<sonar_driver_interfaces::msg::SonarConfiguration>::SharedPtr configurationSubscriber;
 
 protected:
     inline static OculusDriverNode *instance = nullptr;
+
+    std::vector<std::function<void(sonar_driver_interfaces::msg::SonarConfiguration::SharedPtr)>> *configurationListeners;
+    void configurationCallback(sonar_driver_interfaces::msg::SonarConfiguration::SharedPtr msg);
 };
 
 #endif

--- a/include/sonar_driver/sonardevices/oculusMessages.hxx
+++ b/include/sonar_driver/sonardevices/oculusMessages.hxx
@@ -102,7 +102,7 @@ namespace OculusMessages
         uint16_t msgId;       // Message identifier
         uint16_t msgVersion;
         uint32_t payloadSize; // The size of the message payload (header not included)
-        uint16_t spare2;
+        uint16_t spare2;      // This should be the device part number 
     };
 
     typedef struct

--- a/include/sonar_driver/sonardevices/sonardevices.hxx
+++ b/include/sonar_driver/sonardevices/sonardevices.hxx
@@ -105,6 +105,70 @@ namespace SonarDevices
         // Get a string describing the current address or interface location of the sonar
         virtual const char *getLocation() = 0;
 
+        // Get the current fire mode of the sonar device
+        virtual uint8_t getFireMode();
+
+        // Get the current operating frequency of the sonar (Hz)
+        virtual double getOperatingFrequency() = 0;
+
+        // Get the current ping rate of the sonar (Hz)
+        virtual uint8_t getPingRate();
+
+        // Get the operational beam count of the sonar
+        virtual uint16_t getBeamCount() = 0;
+
+        // Get the beam separation of the sonar (degrees)
+        virtual double getBeamSeparation() = 0;
+
+        // Get the absolute minimum range of the sonar (meters)
+        virtual double getMinimumRange() = 0;
+
+        // Get the absolute maximum range of the sonar (meters)
+        virtual double getMaximumRange() = 0;
+
+        // Get the current set range of the sonar (meters)
+        virtual double getCurrentRange();
+
+        // Get the current range resolution of the sonar (meters)
+        virtual double getRangeResolution() = 0;
+
+        // Get the number of range bins.
+        virtual uint32_t getRangeBinCount() = 0;
+
+        // Get the current horizontal field of view of the sonar (degrees)
+        virtual double getHorzFOV() = 0;
+
+        // Get the current vertical field of view of the sonar (degrees)
+        virtual double getVertFOV() = 0;
+
+        // Get the current angular resolution of the sonar (degrees)
+        virtual double getAngularResolution() = 0;
+
+        // Get the current gain of the sonar (%)
+        virtual double getCurrentGain();
+
+        // Get whether the sonar is currently in gain assist mode
+        virtual bool gainAssistEnabled();
+
+        // Get the currently used gamma correction value
+        virtual uint8_t getGamma();
+
+        // Get the currently used speed of sound value (m/s)
+        virtual double getSpeedOfSound();
+
+        // Get the currently used salinity value (ppt)
+        virtual double getSalinity();
+
+        // Get the currently used temperature value (degC)
+        virtual double getTemperature();
+
+        // Get the currently used pressure value (bar)
+        virtual double getPressure();
+
+        // Get the set network speed limit (Mbps)
+        virtual uint8_t getNetworkSpeedLimit();
+
+
     protected:
         SonarState state;
         std::vector<void (*)(SonarImage *)> *callbacks;
@@ -118,6 +182,8 @@ namespace SonarDevices
         double currGain;
         double speedOfSound;
         double salinity;
+        double temperature;
+        double pressure;
         bool gainAssistActive;
         uint8_t gamma;
         uint8_t netSpeedLimit;
@@ -143,12 +209,27 @@ namespace SonarDevices
         virtual uint8_t setPingRate(uint8_t frequency);
         virtual void fire();
         virtual const char *getLocation();
+        virtual double getOperatingFrequency();
+        virtual uint16_t getBeamCount();
+        virtual double getBeamSeparation();
+        virtual double getMinimumRange();
+        virtual double getMaximumRange();
+        virtual double getRangeResolution();
+        virtual uint32_t getRangeBinCount();
+        virtual double getHorzFOV();
+        virtual double getVertFOV();
+        virtual double getAngularResolution();
 
     protected:
+        OculusMessages::OculusPartNumberType partNumber;
         EZSocket::Socket *sonarUDPSocket;
         EZSocket::Socket *sonarTCPSocket;
         char *sonarAddress;
         OculusMessages::PingRateType oculusPingRate;
+        double operatingFrequency;
+        uint16_t beams;
+        uint32_t rangeBinCount;
+
         virtual void invokeCallbacks();
         virtual void processSimplePingResult(OculusMessages::OculusSimplePingResult *msg);
     };

--- a/include/sonar_driver/sonardevices/sonardevices.hxx
+++ b/include/sonar_driver/sonardevices/sonardevices.hxx
@@ -168,6 +168,8 @@ namespace SonarDevices
         // Get the set network speed limit (Mbps)
         virtual uint8_t getNetworkSpeedLimit();
 
+        virtual std::string getDeviceName() = 0;
+
 
     protected:
         SonarState state;
@@ -219,6 +221,7 @@ namespace SonarDevices
         virtual double getHorzFOV();
         virtual double getVertFOV();
         virtual double getAngularResolution();
+        virtual std::string getDeviceName();
 
     protected:
         OculusMessages::OculusPartNumberType partNumber;
@@ -229,6 +232,7 @@ namespace SonarDevices
         double operatingFrequency;
         uint16_t beams;
         uint32_t rangeBinCount;
+        double rangeResolution;
 
         virtual void invokeCallbacks();
         virtual void processSimplePingResult(OculusMessages::OculusSimplePingResult *msg);

--- a/include/sonar_driver/sonardevices/sonardevices.hxx
+++ b/include/sonar_driver/sonardevices/sonardevices.hxx
@@ -236,6 +236,7 @@ namespace SonarDevices
 
         virtual void invokeCallbacks();
         virtual void processSimplePingResult(OculusMessages::OculusSimplePingResult *msg);
+        virtual OculusMessages::OculusPartNumberType determinePartNumber(char *broadcastMessage);
     };
 
 #define OCULUS_UDP_PORT 52102

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,7 @@
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>sonar_driver_interfaces</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/sonar_driver/oculusDriver/oculusDriverNode.cxx
+++ b/src/sonar_driver/oculusDriver/oculusDriverNode.cxx
@@ -28,6 +28,7 @@ OculusDriverNode::OculusDriverNode(const char *nodeName) : rclcpp::Node(nodeName
     sonarTemperature = new sensor_msgs::msg::Temperature();
     sonarTemperature->variance = 0.0;
     sonarOrientation = new geometry_msgs::msg::Vector3Stamped();
+    sonarConfiguration = new sonar_driver_interfaces::msg::SonarConfiguration();
 
     // Initialize publishers
     imagePublisher = this->create_publisher<sensor_msgs::msg::Image>("image", 10);
@@ -37,11 +38,11 @@ OculusDriverNode::OculusDriverNode(const char *nodeName) : rclcpp::Node(nodeName
     configurationPublisher = this->create_publisher<sonar_driver_interfaces::msg::SonarConfiguration>("configuration", 10);
 
     // Initialize subscribers
-    configurationListeners = new std::vector<std::function<void(sonar_driver_interfaces::msg::SonarConfiguration::SharedPtr)>>();
-    configurationSubscriber = this->create_subscription<sonar_driver_interfaces::msg::SonarConfiguration>(
+    configurationListeners = new std::vector<std::function<void(sonar_driver_interfaces::msg::SonarConfigurationChange::SharedPtr)>>();
+    configurationChangeSubscriber = this->create_subscription<sonar_driver_interfaces::msg::SonarConfigurationChange>(
         "reconfigure",
         10,
-        [this](sonar_driver_interfaces::msg::SonarConfiguration::SharedPtr msg) {
+        [this](sonar_driver_interfaces::msg::SonarConfigurationChange::SharedPtr msg) {
             configurationCallback(msg);
         }
     );
@@ -53,12 +54,14 @@ OculusDriverNode::OculusDriverNode(const char *nodeName) : rclcpp::Node(nodeName
     }
 }
 
-void OculusDriverNode::addConfigurationListener(std::function<void(sonar_driver_interfaces::msg::SonarConfiguration::SharedPtr)> callback)
+void OculusDriverNode::addConfigurationListener(std::function<void(sonar_driver_interfaces::msg::SonarConfigurationChange::SharedPtr)> callback)
 {
     configurationListeners->push_back(callback);
 }
 
-void OculusDriverNode::configurationCallback(sonar_driver_interfaces::msg::SonarConfiguration::SharedPtr msg)
+
+
+void OculusDriverNode::configurationCallback(sonar_driver_interfaces::msg::SonarConfigurationChange::SharedPtr msg)
 {
     for (auto &listener : *configurationListeners)
     {
@@ -78,6 +81,8 @@ OculusDriverNode::~OculusDriverNode()
     sonarTemperature = nullptr;
     delete sonarOrientation;
     sonarOrientation = nullptr;
+    delete sonarConfiguration;
+    sonarConfiguration = nullptr;
     delete configurationListeners;
     configurationListeners = nullptr;
 }


### PR DESCRIPTION
**New Features:**
- The node now sends sensor configuration data in a 1-second interval in a custom `SonarConfiguration` message. This configuration data can be used in dynamic pipelines to process the sonar images further.
- The node now listens for `SonarConfigurationChange` messages which can be used to reconfigure the sensor, e.g. change the range or mode of operation.
- The node is now able to automatically detect the used sensor. This is used to determine additional sensor parameters as shown in the `SonarConfiguration` message